### PR TITLE
[fix] dev/random -> dev/urandom

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -319,7 +319,7 @@ test_all () {
     run_test 'ls | wc | wc ; echo test'
     run_test 'ls | wc | wc ; echo test | wc'
     run_test "echo \$USER \"  \$HOME  \" | cat | head -n 1 | cat | cat | wc"
-    run_test 'cat /dev/random | head -c 100 | wc -c'
+    run_test 'cat /dev/urandom | head -c 100 | wc -c'
     # run_test 'sleep 1 | echo 1 ; sleep 2 | echo 2'
 
 


### PR DESCRIPTION
環境(Ubuntu 20.04 on WSL2)によってはdev/randomでブロックが発生して、テストが停止する場合があったので、dev/randomをdev/urandomに変更